### PR TITLE
Changed tasks.withType(Compile) to JavaCompile, since Compile has been d...

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -10,7 +10,7 @@
  * "work for hire", who hereby disclaims any copyright to the same.
  */
 
-tasks.withType(Compile) {
+tasks.withType(JavaCompile) {
     options.compilerArgs << "-Xlint:unchecked"
 }
 


### PR DESCRIPTION
...epreciated in favor of JavaCompile and was finally removed in 2.0
