### PR TITLE
Minor enhancements to thread safe implementation of three classes

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/service/EntityJobStore.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/service/EntityJobStore.groovy
@@ -51,6 +51,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import javax.sql.rowset.serial.SerialBlob
+import java.util.concurrent.atomic.AtomicLong
 
 // NOTE: Implementing a Quartz JobStore is a HUGE PITA, Quartz puts a lot of scheduler and state handling logic in the
 //     JobStore. The code here is based mostly on the JobStoreSupport class to replicate that logic.
@@ -1041,8 +1042,8 @@ class EntityJobStore implements JobStore {
         return nextTriggers
     }
 
-    protected static long ftrCtr = System.currentTimeMillis()
-    protected synchronized String getFiredTriggerRecordId() { return instanceId + ftrCtr++ }
+    protected static AtomicLong ftrCtr = new AtomicLong(System.currentTimeMillis())
+    protected String getFiredTriggerRecordId() { return instanceId + ftrCtr.getAndIncrement() }
 
     protected int updateTriggerState(TriggerKey triggerKey, String state) {
         return ecfi.entityFacade.find("moqui.service.quartz.QrtzTriggers")

--- a/framework/src/test/groovy/ServiceFacadeTests.groovy
+++ b/framework/src/test/groovy/ServiceFacadeTests.groovy
@@ -1,0 +1,45 @@
+/*
+ * This Work is in the public domain and is provided on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE,
+ * NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ * You are solely responsible for determining the appropriateness of using
+ * this Work and assume any risks associated with your use of this Work.
+ *
+ * This Work includes contributions authored by David E. Jones, not as a
+ * "work for hire", who hereby disclaims any copyright to the same.
+ */
+
+
+import org.moqui.impl.service.ServiceFacadeImpl
+import org.moqui.service.ServiceCallback
+import spock.lang.*
+
+import org.moqui.context.ExecutionContext
+import org.moqui.Moqui
+
+class ServiceFacadeTests extends Specification {
+    @Shared
+    ExecutionContext ec
+
+    def setupSpec() {
+        // init the framework, get the ec
+        ec = Moqui.getExecutionContext()
+    }
+
+    def cleanupSpec() {
+        ec.destroy()
+    }
+
+    def "register callback concurrently"() {
+        def sfi = (ServiceFacadeImpl)ec.service
+        ServiceCallback scb = Mock(ServiceCallback)
+
+        when:
+        ConcurrentExecution.executeConcurrently(10, { sfi.registerCallback("foo", scb) })
+        sfi.callRegisteredCallbacks("foo", null, null)
+
+        then:
+        10 * scb.receiveEvent(null, null)
+    }
+}


### PR DESCRIPTION
This pull request contains 4 commits that are independent: you can include/discard any of them (or all!).
The first one is a trivial refactoring to EntityJobStore.getFiredTriggerRecordId; it should be safe to merge it.
The second one is a refactoring of the ServiceResultWaiter class: it simplifies its state and should make it easier to reason around thread safety but if you don't like it just leave it out (or I can submit a new pull request if you prefer).
The third one implement a unit test for the concurrent access to registerCallback: in my opinion it should be merged; it is a simple test but quite interesting because of concurrency and of mocks (it can be a good reference for similar tests).
The last one if a refactoring to thread safe implementation of registerCallback: in my opinion it should be committed but leave it out if you don't like the approach (it is similar to what I did in my previous pull request that was merged).
