### PR TITLE
Loading seed into create-only entity

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityValueBase.groovy
@@ -1086,6 +1086,11 @@ abstract class EntityValueBase implements EntityValue {
                 nonPkFieldList.add(fieldName)
             }
         }
+        
+        if (ed.createOnly() && dbValueMapFromDb && nonPkFieldList) {
+            throw new EntityException("Entity [${getEntityName()}] is create-only (immutable), cannot be updated.")
+        }
+        
         // logger.warn("================ evb.update() ${getEntityName()} nonPkFieldList=${nonPkFieldList};\nvalueMap=${valueMap};\ndbValueMap=${dbValueMap}")
         if (!nonPkFieldList) {
             if (logger.isTraceEnabled()) logger.trace((String) "Not doing update on entity with no populated non-PK fields; entity=" + this.toString())


### PR DESCRIPTION
Dataseed loading into create-only entity should not fail if the entityValues are same.

This is to avoid unnecessary blocking error during seeds loading on non empty database.
