### PR TITLE
Handled the use case when searched string is part of the entity name

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityFacadeImpl.groovy
@@ -920,7 +920,8 @@ class EntityFacadeImpl implements EntityFacade {
 
         List<Map<String, Object>> eil = new LinkedList()
         for (String en in getAllEntityNames()) {
-            if (filterRegexp && !en.matches(filterRegexp)) continue
+            // Added (?i) to ignore the case and '*' in the starting and at ending to match if searched string is sub-part of entity name
+            if (filterRegexp && !en.matches("(?i).*" + filterRegexp + ".*")) continue
             EntityDefinition ed = null
             try { ed = getEntityDefinition(en) } catch (EntityException e) { logger.warn("Problem finding entity definition", e) }
             if (ed == null) continue


### PR DESCRIPTION
_Purpose_: When a user enters the string for a filter which is sub-part of entity name (or may be different in case) in this situation also the entity in the search list should be shown.
Please refer below for the example.

When we search for entity in Entity tools at http://demo.moqui.org/apps/tools/Entity/DataEdit/EntityList
for e.g. we searched for the keyword **'status'**

**No results are shown** because as per our current code, it is looking for the exact match which should be something like this **'moqui.basic.StatusItem'**

![entities_list](https://cloud.githubusercontent.com/assets/7145848/11016823/3aa24c44-85b2-11e5-8603-eb20beca69a7.png)

As per the current commit, I have tried to handled the ignoring the case as well as it the searched string is the subpart of the entity name, that entity will be listed.

![updated_entity_list](https://cloud.githubusercontent.com/assets/7145848/11016825/4021e4a4-85b2-11e5-8c10-26f54289f98c.png)

Thanks in advance for reviewing the pull request.
Kindly let me know if I understand any thing incorrectly or you need more explanation on this. Also, please suggest if any updates required :smiley: !
