### PR TITLE
Add gradle command line/parameter for moqui

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ task run(type: JavaExec) {
     systemProperties = ['moqui.conf':moquiConfDev, 'moqui.runtime':moquiRuntime]
     // NOTE: this is a hack, using -jar instead of a class name, and then the first argument is the name of the jar file
     main = '-jar'; args = [warName]
+    // passing args to moqui, using -Pmoquiargs=...
+    if (project.hasProperty('moquiargs')) {
+        args(moquiargs.split(','))
+    }
 }
 task runStaging(type: JavaExec) {
     dependsOn allBuildTasks
@@ -71,6 +75,9 @@ task runStaging(type: JavaExec) {
     workingDir = '.'; jvmArgs = ['-server', '-XX:MaxPermSize=192m', '-Xms512M']; maxHeapSize = '512M'
     systemProperties = ['moqui.conf':'conf/MoquiStagingConf.xml', 'moqui.runtime':moquiRuntime]
     main = '-jar'; args = [warName]
+    if (project.hasProperty('moquiargs')) {
+        args(moquiargs.split(','))
+    }
 }
 task runProduction(type: JavaExec) {
     dependsOn allBuildTasks
@@ -78,6 +85,9 @@ task runProduction(type: JavaExec) {
     workingDir = '.'; jvmArgs = ['-server', '-XX:MaxPermSize=192m', '-Xms1024M']; maxHeapSize = '1024M'
     systemProperties = ['moqui.conf':moquiConfProduction, 'moqui.runtime':moquiRuntime]
     main = '-jar'; args = [warName]
+    if (project.hasProperty('moquiargs')) {
+        args(moquiargs.split(','))
+    }
 }
 
 // use user-specified command line args like: "gradle load -Ptypes=seed -PtenantId=EXAMPLE1"


### PR DESCRIPTION
With this change, we can pass parameter to moqui (and windstone).
See for reference http://stackoverflow.com/questions/11696521/how-to-pass-arguments-from-command-line-to-gradle

Now we can do this, for example:

`C:\> gradle run -Pmoquiargs=--httpPort=8181,--httpsPort=8989,--httpsCertificate=..\test.cert,--httpsPrivateKey=..\test.key`
